### PR TITLE
Update to 1.21.2-1.21.4; update Gradle and adress deprecation warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 plugins {
-    id 'fabric-loom' version '1.6-SNAPSHOT'
+    id 'fabric-loom' version '1.9-SNAPSHOT'
     id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_21
-targetCompatibility = JavaVersion.VERSION_21
-
-archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
+
+base {
+    archivesName = project.archives_base_name
+}
 
 repositories {
     // Add repositories to retrieve artifacts from in here.
@@ -16,6 +16,18 @@ repositories {
     // Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
     // See https://docs.gradle.org/current/userguide/declaring_repositories.html
     // for more information about repositories.
+}
+
+loom {
+    splitEnvironmentSourceSets()
+
+    mods {
+        "modid" {
+            sourceSet sourceSets.main
+            sourceSet sourceSets.client
+        }
+    }
+
 }
 
 dependencies {
@@ -30,20 +42,21 @@ processResources {
     filesMatching("fabric.mod.json") {
         expand "version": project.version
     }
-
 }
-// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-// if it is present.
-// If you remove this task, sources will not be generated.
+
 tasks.withType(JavaCompile).configureEach {
     // Minecraft 1.20.5 upwards uses Java 21.
     it.options.release = 21
 }
+
 java {
     // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
     // if it is present.
     // If you remove this line, sources will not be generated.
     withSourcesJar()
+
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 loom {
@@ -52,17 +65,18 @@ loom {
 
 jar {
     from("LICENSE") {
-        rename { "${it}_${project.archivesBaseName}"}
+        rename { "${it}_${project.base.archivesName.get()}"}
     }
 }
 
 // configure the maven publication
 publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-        }
-    }
+	publications {
+		create("mavenJava", MavenPublication) {
+			artifactId = project.archives_base_name
+			from components.java
+		}
+	}
 
     // See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
 
-minecraft_version=1.21
-yarn_mappings=1.21+build.9
-loader_version=0.16.3
+minecraft_version=1.21.4
+yarn_mappings=1.21.4+build.7
+loader_version=0.16.9
 # Mod Properties
-mod_version=1.3-1.21
+mod_version=1.3-1.21.4
 maven_group=capitalistspz
 archives_base_name=snowballkb

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/capitalistspz/test/config/Config.java
+++ b/src/main/java/capitalistspz/test/config/Config.java
@@ -3,6 +3,7 @@ package capitalistspz.test.config;
 import capitalistspz.test.SnowballKB;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.Strictness;
 import org.apache.logging.log4j.Level;
 
 import java.io.File;
@@ -20,7 +21,7 @@ public class Config{
     public float fishingRodPullMultiplier = 0.1f;
 
     private static final File configFile = new File("config" + File.separator + "snowballkb.json");
-    private static final Gson gson = new GsonBuilder().setPrettyPrinting().setLenient().create();
+    private static final Gson gson = new GsonBuilder().setPrettyPrinting().setStrictness(Strictness.LENIENT).create();
 
     public static boolean save(Config config) {
         try {

--- a/src/main/java/capitalistspz/test/mixin/EggEntityMxn.java
+++ b/src/main/java/capitalistspz/test/mixin/EggEntityMxn.java
@@ -6,6 +6,7 @@ import net.minecraft.entity.EntityType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.thrown.EggEntity;
 import net.minecraft.entity.projectile.thrown.ThrownItemEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.hit.EntityHitResult;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
@@ -36,7 +37,11 @@ public abstract class EggEntityMxn extends ThrownItemEntity {
                 player.setVelocity(player.getVelocity().add(this.getVelocity().normalize().multiply(SnowballKB.config.eggKbMultiplier)));
                 player.velocityModified = true;
             }
-            entity.damage(this.getDamageSources().thrown(this, this.getOwner()), SnowballKB.config.eggDamage);
+
+            if (entity.getWorld() instanceof ServerWorld world) {
+                entity.damage(world, this.getDamageSources().thrown(this, this.getOwner()),
+                        SnowballKB.config.eggDamage);
+            }
         }
 
     }

--- a/src/main/java/capitalistspz/test/mixin/SnowballEntityMxn.java
+++ b/src/main/java/capitalistspz/test/mixin/SnowballEntityMxn.java
@@ -6,6 +6,7 @@ import net.minecraft.entity.EntityType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.thrown.SnowballEntity;
 import net.minecraft.entity.projectile.thrown.ThrownItemEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.hit.EntityHitResult;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
@@ -36,7 +37,11 @@ public abstract class SnowballEntityMxn extends ThrownItemEntity {
                 entity.setVelocity(entity.getVelocity().add(this.getVelocity().normalize().multiply(SnowballKB.config.snowKbMultiplier)));
                 entity.velocityModified = true;
             }
-            entity.damage(this.getDamageSources().thrown(this, this.getOwner()), SnowballKB.config.snowDamage);
+
+            if (entity.getWorld() instanceof ServerWorld world) {
+                entity.damage(world, this.getDamageSources().thrown(this, this.getOwner()),
+                        SnowballKB.config.snowDamage);
+            }
         }
 
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,6 +21,6 @@
   "accessWidener" : "snowballkb.accesswidener",
   "depends": {
     "fabricloader": ">=0.15.11",
-    "minecraft": ">=1.21"
+    "minecraft": ">=1.21.2"
   }
 }


### PR DESCRIPTION
Hi, I experienced a crash when trying the current version on 1.21.4 and updated the code to work.
I also did some upgrades to Gradle and Loom tooling, fixing all deprecation issues that were reported when compiling.

I'll explain both separately in the following sections.

I did everything needed I think, please check and if you think it's good, you just need to do the release. :+1: :smiley: 
All is tested and works on my side also.

### The version update
The parameters for the damage method changed, so I followed the recommendations in the Fabric blog as quoted below:
 (actually `serverDamage` would have the same parameters as previous damage, but it is already deprecated).
https://fabricmc.net/2024/10/14/1212.html
> **ServerWorld parameters**
> 
> Many methods that must be executed on the server side only now require ServerWorld to be passed explicitly. Do not cast just to fix a type error; many events and overridden method are still called on both the client side and the server side.
> 
> Instead, wrap all logic that must be run only on the server side with if (world instanceof ServerWorld serverWorld). The serverWorld can be passed to those methods.
> 
> For example, Entity#damage now requires ServerWorld, and is therefore only called on the server side. There is an additional method, clientDamage, which is called only on the client side.

This leads to only this change:
```java
if (entity.getWorld() instanceof ServerWorld world) {
  entity.damage(world, this.getDamageSources().thrown(this, this.getOwner()),
       SnowballKB.config.snowDamage);
}
```
All is tested and works.

I adjusted the Minecraft version requirement and set the version number to `1.3-1.21.4` in accordance to your versioning I saw on Modrinth.
**Please check if everything is alright. :)**

### Tooling 

##### Gradle
When first building, I received the following warnings when running `./gradlew build --warning-mode all`:
- The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.7/userguide/upgrading_version_8.html#java_convention_deprecation
- The org.gradle.api.plugins.BasePluginConvention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.7/userguide/upgrading_version_8.html#base_convention_deprecation
- The BasePluginExtension.archivesBaseName property has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the archivesName property instead. For more information, please refer to https://docs.gradle.org/8.7/dsl/org.gradle.api.plugins.BasePluginExtension.html#org.gradle.api.plugins.BasePluginExtension:archivesName in the Gradle documentation.

Since they are self-explanatory, I fixed them according to what was written, while also cross-referencing how the Fabric example mod did it.

#### Loom
Upgraded Loom to latest (1.9). The Loom upgrade also required a newer Gradle version, so I updated the gradle wrapper to 8.11.

##### Other
Finally, Gson deprecated the setLenient() method.
Replaced it by `setStrictness(Strictness.LENIENT)` as stated here: https://javadoc.io/doc/com.google.code.gson/gson/latest/deprecated-list.html
